### PR TITLE
Remove angular velocity conversion

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -148,14 +148,6 @@ SecondaryStates Task::getSecondaryStates(const base::LinearAngular6DCommand &con
     return secondary_states;
 }
 
-base::Vector3d Task::eulerToAxisAngle(const base::Vector3d &states)
-{
-    Eigen::AngleAxisd axisAngle = Eigen::AngleAxisd(Eigen::AngleAxisd(states(2), Eigen::Vector3d::UnitZ()) *
-                                  Eigen::AngleAxisd(states(1), Eigen::Vector3d::UnitY()) *
-                                  Eigen::AngleAxisd(states(0), Eigen::Vector3d::UnitX()));
-    return axisAngle.angle() * axisAngle.axis();
-}
-
 void Task::setUncertainty(base::samples::RigidBodyState &states)
 {
     base::Vector6d velocityUncertainty = _velocity_uncertainty.get();

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -58,10 +58,6 @@ namespace uwv_dynamic_model {
 	SecondaryStates getSecondaryStates(const base::LinearAngular6DCommand &control_input, const AccelerationState &acceleration);
 
 	/**
-	 * Transforms a set of coordinates from euler to axis-angle representation
-	 */
-	base::Vector3d eulerToAxisAngle(const base::Vector3d &states);
-	/**
 	 * Sets the uncertainty value for pose and velocity
 	 */
 	void setUncertainty(base::samples::RigidBodyState &states);


### PR DESCRIPTION
This should be fine, only waiting for a final conclusion (from Sascha and Christoph) about the lack of need for these conversions
