### PR TITLE
Remove auv_control dependency

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -13,6 +13,5 @@
   <depend package="base/cmake" />
   <depend package="drivers/orogen/transformer"/>
   <depend package="control/uwv_dynamic_model"/>
-  <depend package="control/orogen/auv_control"/>
   <depend package="base/numeric"/>
 </package>

--- a/uwv_dynamic_model.orogen
+++ b/uwv_dynamic_model.orogen
@@ -5,7 +5,6 @@ using_library "numeric"
 import_types_from "base"
 import_types_from "uwv_dynamic_model/DataTypes.hpp"
 import_types_from "uwv_dynamic_modelTypes.hpp"
-import_types_from "auv_control"
 
 task_context "Task" do
     needs_configuration

--- a/uwv_dynamic_model.orogen
+++ b/uwv_dynamic_model.orogen
@@ -1,7 +1,7 @@
 name "uwv_dynamic_model"
 
 using_library "uwv_dynamic_model"
-using_library "numeric"
+using_library "numeric" # Imports SavitzkyGolayFilter's library
 import_types_from "base"
 import_types_from "uwv_dynamic_model/DataTypes.hpp"
 import_types_from "uwv_dynamic_modelTypes.hpp"
@@ -56,16 +56,16 @@ task_context "Task" do
 end
 
 
-# The aims of VelocityEstimator is to be a simple Model Based Velocity Estimator.
+# The aim of VelocityEstimator is to be a simple Model Based Velocity Estimator.
 #
 # It integrates sensors data direct to the model's states,
 # without using any filter, like Kalman-Filter.
 #
-# It is based on the assuption that orientation, angular velocity
+# It is based on the assumption that orientation, angular velocity
 # and depth are provided by sensors at a high rate and precision.
 #
-# For acoustic sensor, i.e. dvl, which latency time is significant,
-# the componente replay the model with storage states and commands,
+# For acoustic sensor, i.e. dvl, whose latency time is significant,
+# the component replays the model with storaged states and commands,
 # correcting model's uncertainty with measured data.
 #
 # For the particular case of vertical velocity, depth sample is

--- a/uwv_dynamic_modelTypes.hpp
+++ b/uwv_dynamic_modelTypes.hpp
@@ -8,7 +8,7 @@
  * which case you do not need this file
  */
 #include <base/samples/RigidBodyAcceleration.hpp>
-#include <auv_control/6dControl.hpp>
+#include <base/commands/LinearAngular6DCommand.hpp>
 
 namespace uwv_dynamic_model
 {


### PR DESCRIPTION
@saarnold @doudou 

LinearAngular6DCommand has been moved to base/types, so it does not depend any longer on auv_control.

This PR depends on:

 - [x] https://github.com/rock-core/base-types/pull/96
 - [x] https://github.com/rock-core/base-orogen-types/pull/22