### PR TITLE
Reset states when in stopHook

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -40,7 +40,6 @@ bool Task::startHook()
 {
     if (! TaskBase::startHook())
         return false;
-
     return true;
 }
 void Task::updateHook()
@@ -189,6 +188,7 @@ void Task::errorHook()
 void Task::stopHook()
 {
     TaskBase::stopHook();
+    model_simulation->resetStates();
 }
 void Task::cleanupHook()
 {


### PR DESCRIPTION
The component was going into the following exception:

```
77.019 [ ERROR  ][OrbRunner] in updateHook(): switching to exception state because of unhandled exception
77.019 [ ERROR  ][OrbRunner]   KinematicModel checkVelocity: velocity is unset
```

When the following steps were executed:

1 - Run the component
2 - Stop the component
3 - Start the component